### PR TITLE
Don't panic when etcd server lost connection.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ pub struct Inner {
     /// Auth client for authentication operations.
     auth_client: Auth,
     /// Key-Value client for key-value operations.
-    kv_client: Kv,
+    kv_client: Arc<Kv>,
     /// Watch client for watch operations.
     watch_client: Watch,
     /// Lease client for lease operations.
@@ -163,8 +163,8 @@ impl Client {
     /// Gets a key-value client.
     #[inline]
     #[must_use]
-    pub fn kv(&self) -> Kv {
-        self.inner.kv_client.clone()
+    pub fn kv(&self) -> Arc<Kv> {
+        Arc::<Kv>::clone(&self.inner.kv_client)
     }
 
     /// Get a lock client.

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,4 +16,7 @@ pub enum EtcdError {
     /// SendError for EtcdLeaseKeepAliveRequest
     #[error("send error for EtcdLeaseKeepAliveRequest")]
     SendFailedForLeaseKeepAliveRequest(#[from] SendError<EtcdLeaseKeepAliveRequest>),
+    /// Internal Error
+    #[error("Internal Error: {0}")]
+    InternalError(String),
 }


### PR DESCRIPTION
Just set the error state in the KV when any watch related error met.
Any following operations report this error.

In some tests the sever closes first, we should ignore the error until
there are other following operations.