### PR TITLE
Add func to get type of event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+    branches: [master]
+  workflow_dispatch: 
   # schedule: [cron: "0 0 * * *"]
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
   pull_request:
-  schedule: [cron: "0 0 * * *"]
+  # schedule: [cron: "0 0 * * *"]
 
 env:
   CI_RUST_TOOLCHAIN: 1.56.1

--- a/etcd-client/Cargo.toml
+++ b/etcd-client/Cargo.toml
@@ -32,7 +32,7 @@ smol = "1.2.4"
 thiserror = "1.0"
 
 [dev-dependencies]
-env_logger = "0.8.1"
+env_logger = "0.8.4"
 
 [build-dependencies]
 protoc-grpcio = "2.0.0"

--- a/etcd-client/src/watch/mod.rs
+++ b/etcd-client/src/watch/mod.rs
@@ -168,8 +168,6 @@ impl Shutdown for WatchTunnel {
 /// Watch client.
 #[derive(Clone)]
 pub struct Watch {
-    /// Etcd watch client provides watch realted operations.
-    client: WatchClient,
     /// A tunnel used to communicate with Etcd server for watch operations.
     tunnel: Arc<Lazy<WatchTunnel>>,
 }
@@ -178,11 +176,10 @@ impl Watch {
     /// Create a new `WatchClient`.
     pub(crate) fn new(client: WatchClient) -> Self {
         let tunnel = {
-            let client = client.clone();
-            Arc::new(Lazy::new(move || WatchTunnel::new(&client.clone())))
+            Arc::new(Lazy::new(move || WatchTunnel::new(&client)))
         };
 
-        Self { client, tunnel }
+        Self { tunnel }
     }
 
     /// Performs a watch operation.
@@ -250,6 +247,12 @@ impl Event {
     #[inline]
     pub fn take_kvs(&mut self) -> Option<EtcdKeyValue> {
         self.proto.kv.take().map(From::from)
+    }
+
+    /// Get the type of event
+    #[inline]
+    pub fn event_type(&self) -> EventType {
+        EventType::from(self.proto.get_field_type())
     }
 }
 


### PR DESCRIPTION
When implementing waiting for a key to be deleted, the event this lib returned has no func to verify the type of event (Put or delete)