### PR TITLE
Refactor to support multi-task watch operations and automatically cancel watch when dropping the receiver.

### DIFF
--- a/etcd-client/Cargo.toml
+++ b/etcd-client/Cargo.toml
@@ -30,7 +30,7 @@ priority-queue = "1.0.5"
 protobuf = "2.16.2"
 smol = "1.2.4"
 thiserror = "1.0"
-crossbeam-queue = "0.3.1"
+crossbeam-queue = "0.3.8"
 async-broadcast = "0.5.1"
 
 [dev-dependencies]

--- a/etcd-client/Cargo.toml
+++ b/etcd-client/Cargo.toml
@@ -30,6 +30,8 @@ priority-queue = "1.0.5"
 protobuf = "2.16.2"
 smol = "1.2.4"
 thiserror = "1.0"
+crossbeam-queue = "0.3.1"
+async-broadcast = "0.5.1"
 
 [dev-dependencies]
 env_logger = "0.8.4"

--- a/etcd-client/src/client.rs
+++ b/etcd-client/src/client.rs
@@ -193,8 +193,12 @@ impl Client {
     }
 
     /// Perform a watch operation
+    ///
+    ///  # Errors
+    ///
+    /// etcd error: client closed
     #[inline]
-    pub async fn watch(&self, key_range: KeyRange) -> Option<SingleWatchEventReceiver> {
+    pub async fn watch(&self, key_range: KeyRange) -> Result<SingleWatchEventReceiver> {
         let mut client = self.inner.watch_client.clone();
         client.watch(key_range).await
     }

--- a/etcd-client/src/client.rs
+++ b/etcd-client/src/client.rs
@@ -1,15 +1,16 @@
 use std::sync::Arc;
 
-use smol::stream::Stream;
 use std::net::SocketAddr;
 
 use grpcio::{Channel, ChannelBuilder, EnvBuilder, LbPolicy};
 
-use crate::protos::{
-    lock_grpc::LockClient,
-    rpc_grpc::{AuthClient, KvClient, LeaseClient, WatchClient},
+use crate::{
+    protos::{
+        lock_grpc::LockClient,
+        rpc_grpc::{AuthClient, KvClient, LeaseClient, WatchClient},
+    },
+    watch::SingleWatchEventReceiver,
 };
-use crate::watch::EtcdWatchResponse;
 use crate::{Auth, KeyRange, Kv, Lease, Lock, Result, Watch};
 
 /// Config for establishing etcd client.
@@ -150,13 +151,13 @@ impl Client {
             inner: Arc::new(Inner {
                 channel: channel.clone(),
                 auth_client: Auth::new(AuthClient::new(channel.clone())),
+                watch_client: Watch::new(&etcd_watch_client),
                 kv_client: Kv::new(
                     KvClient::new(channel.clone()),
-                    etcd_watch_client.clone(),
+                    etcd_watch_client,
                     cfg.cache_size,
                     cfg.cache_enable,
                 ),
-                watch_client: Watch::new(etcd_watch_client),
                 lease_client: Lease::new(LeaseClient::new(channel.clone())),
                 lock_client: Lock::new(LockClient::new(channel)),
             }),
@@ -193,10 +194,7 @@ impl Client {
 
     /// Perform a watch operation
     #[inline]
-    pub async fn watch(
-        &self,
-        key_range: KeyRange,
-    ) -> impl Stream<Item = Result<EtcdWatchResponse>> {
+    pub async fn watch(&self, key_range: KeyRange) -> Option<SingleWatchEventReceiver> {
         let mut client = self.inner.watch_client.clone();
         client.watch(key_range).await
     }

--- a/etcd-client/src/error.rs
+++ b/etcd-client/src/error.rs
@@ -24,4 +24,7 @@ pub enum EtcdError {
     /// Internal Error
     #[error("Internal Error: {0}")]
     InternalError(String),
+    /// waiting for response timeout
+    #[error("waiting for response timeout: {0}")]
+    WaitingResponseTimeout(String),
 }

--- a/etcd-client/src/error.rs
+++ b/etcd-client/src/error.rs
@@ -27,4 +27,7 @@ pub enum EtcdError {
     /// waiting for response timeout
     #[error("waiting for response timeout: {0}")]
     WaitingResponseTimeout(String),
+    /// Client closed
+    #[error("etcd client closed: {0}")]
+    ClientClosed(String),
 }

--- a/etcd-client/src/kv/mod.rs
+++ b/etcd-client/src/kv/mod.rs
@@ -40,6 +40,8 @@ use protobuf::RepeatedField;
 use smol::channel::{unbounded, Sender};
 use smol::Timer;
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::fmt::{Debug, Display};
 use std::str;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
@@ -672,11 +674,28 @@ impl From<KeyValue> for EtcdKeyValue {
 }
 
 /// `KeyRange` is an abstraction for describing etcd key of various types.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct KeyRange {
     /// The first key of the range and should be non-empty
     key: Vec<u8>,
     /// The key following the last key of the range
     range_end: Vec<u8>,
+}
+
+impl Display for KeyRange {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Write strictly the first element into the supplied output
+        // stream: `f`. Returns `fmt::Result` which indicates whether the
+        // operation succeeded or failed. Note that `write!` uses syntax which
+        // is very similar to `println!`.
+        write!(
+            f,
+            "keyrange( begin:{}, end:{} )",
+            str::from_utf8(&self.key).unwrap_or("not utf8"),
+            str::from_utf8(&self.range_end).unwrap_or("not utf8")
+        )
+    }
 }
 
 impl KeyRange {

--- a/etcd-client/src/lease/mod.rs
+++ b/etcd-client/src/lease/mod.rs
@@ -98,7 +98,7 @@ struct LeaseKeepAliveTunnel {
     req_sender: Sender<EtcdLeaseKeepAliveRequest>,
     /// A channel receiver to receive keep alive response.
     resp_receiver: Option<Receiver<Result<EtcdLeaseKeepAliveResponse>>>,
-    /// A channel sender to send shutdowm request.
+    /// A channel sender to send shutdown request.
     shutdown: Option<Sender<()>>,
 }
 

--- a/etcd-client/src/lib.rs
+++ b/etcd-client/src/lib.rs
@@ -220,7 +220,12 @@ mod tests {
 
     #[test]
     fn test_all() -> Result<()> {
-        env_logger::init();
+        set_var("RUST_LOG", "debug");
+
+        env_logger::try_init().unwrap_or_else(|e| {
+            log::debug!("env_logger try init failed, err:{}", e);
+        });
+
         smol::block_on(Compat::new(async {
             test_kv().await?;
             test_transaction().await?;
@@ -233,7 +238,10 @@ mod tests {
     #[test]
     fn test_watch_wrap() -> Result<()> {
         set_var("RUST_LOG", "debug");
-        env_logger::init();
+
+        env_logger::try_init().unwrap_or_else(|e| {
+            log::debug!("env_logger try init failed, err:{}", e);
+        });
 
         smol::block_on(Compat::new(async {
             test_watch().await?;

--- a/etcd-client/src/watch/mod.rs
+++ b/etcd-client/src/watch/mod.rs
@@ -40,128 +40,506 @@
 //!
 //! ```
 
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
 
+use async_broadcast::{InactiveReceiver, Receiver as BroadcastRx, Sender as BroadcastTx};
+use async_std::channel::bounded;
 use async_trait::async_trait;
+use crossbeam_queue::SegQueue;
 use futures::future::FutureExt;
-
 use futures::stream::StreamExt;
-use smol::channel::{unbounded, Receiver, Sender};
-use smol::stream::Stream;
+use futures::{SinkExt, TryFutureExt};
+use grpcio::{StreamingCallSink, WriteFlags};
+use smol::channel::{unbounded, Sender};
+use smol::Task;
 
 pub use watch_impl::{EtcdWatchRequest, EtcdWatchResponse};
 
-use futures::prelude::*;
-
 use crate::lazy::{Lazy, Shutdown};
 use crate::protos::kv;
-use crate::protos::rpc;
+use crate::protos::rpc::WatchRequest;
 use crate::protos::rpc_grpc::WatchClient;
 use crate::EtcdKeyValue;
 use crate::KeyRange;
 use crate::Result;
-use grpcio::WriteFlags;
 
 /// Watch implementation mod.
 mod watch_impl;
 
+/// the timeout of waiting etcd response
+const WATCH_REQUEST_TIMEOUT_SEC: u64 = 2;
+
+/// watch id
+type WatchID = i64;
+
+/// the recorded watch info in a lock
+#[derive(Default)]
+struct WatchedMap {
+    /// keyrange to watchid
+    keyrange_2_watchid: BTreeMap<KeyRange, WatchID>,
+    /// watchid to (sender to user, user receiver)
+    watchid_2_detail: HashMap<
+        WatchID,
+        (
+            BroadcastTx<Option<EtcdWatchResponse>>,
+            Weak<SingleWatchEventReceiverInner>,
+        ),
+    >,
+}
+impl WatchedMap {
+    /// add new watched info
+    fn add_watched(
+        &mut self,
+        watchid: WatchID,
+        keyrange: KeyRange,
+        sender_2_user: BroadcastTx<Option<EtcdWatchResponse>>,
+        user_receiver: Weak<SingleWatchEventReceiverInner>,
+    ) {
+        self.keyrange_2_watchid.insert(keyrange, watchid);
+        self.watchid_2_detail
+            .insert(watchid, (sender_2_user, user_receiver));
+    }
+    /// remove the watch to cancel
+    fn remove_watch(&mut self, keyrange: &KeyRange) -> Option<WatchID> {
+        if let Some(watch_id) = self.keyrange_2_watchid.remove(keyrange) {
+            log::debug!("removed watch");
+            drop(
+                self.watchid_2_detail
+                    .remove(&watch_id)
+                    .unwrap_or_else(|| panic!("")),
+            );
+            return Some(watch_id);
+        }
+        None
+    }
+
+    /// get sender 2 user to send watched event
+    fn get_sender_2_user(
+        &self,
+        watchid: WatchID,
+    ) -> Option<BroadcastTx<Option<EtcdWatchResponse>>> {
+        if let Some(&(ref sender, _)) = self.watchid_2_detail.get(&watchid) {
+            return Some(sender.clone());
+        }
+        None
+    }
+
+    /// get receiver of key range to send back to user who requested watch
+    fn get_arc_receiver(&self, keyrange: &KeyRange) -> Option<SingleWatchEventReceiver> {
+        self.keyrange_2_watchid.get(keyrange).and_then(|id|{
+            if let Some(&(_,ref weak_receiver_inner)) = self.watchid_2_detail.get(id) {
+                match weak_receiver_inner.upgrade() {
+                    Some(arc_receiver_inner) => Some(SingleWatchEventReceiver::from_exist_inner(
+                        arc_receiver_inner,
+                    )),
+                    None => {
+                        // `remove_watch` in `WatchedMap` should be called when receiver is dropped
+                        panic!(
+                            "Receivers were all dropped but the registed info has not been removed, which is impossible"
+                        );
+                    }
+                }
+            } else {
+                None
+            }
+        })
+    }
+}
+
+/// Watch related data shared between watch communication task and user receivers
+struct WatchTunnelShared {
+    /// A map shared to get the sender to registed watches for a keyrange
+    watched_map: Lazy<WatchedMap>,
+    /// Queued watch requests
+    queued_watch_requests: SegQueue<(EtcdWatchRequest, Sender<Option<SingleWatchEventReceiver>>)>,
+    /// Watch request waiting for response
+    waiting_watch_request: Lazy<Option<(KeyRange, Sender<Option<SingleWatchEventReceiver>>)>>,
+
+    /// A channel sender to send cancel request to etcd
+    ///  cancel request: KeyRange to find the watch id and
+    cancel_req_sender: Sender<WatchID>,
+    /// Waiting cancel requests, bool refers to whether the response arrived in time
+    waiting_cancels: Lazy<HashMap<WatchID, Sender<()>>>,
+
+    /// A channel sender to send shutdowm request.
+    shutdown: Sender<()>,
+
+    /// Sub tasks
+    sub_tasks: Option<SegQueue<Task<()>>>,
+}
+impl Drop for WatchTunnelShared {
+    fn drop(&mut self) {
+        let sub_tasks = self
+            .sub_tasks
+            .take()
+            .unwrap_or_else(|| panic!("sub_tasks should be some until dropped"));
+        futures::executor::block_on(async {
+            while let Some(task) = sub_tasks.pop() {
+                task.await;
+            }
+        });
+    }
+}
+impl WatchTunnelShared {
+    /// new `WatchTunnelShared`
+    fn new(cancel_req_sender: Sender<WatchID>, shutdown: Sender<()>) -> Self {
+        Self {
+            watched_map: Lazy::new(WatchedMap::default),
+            waiting_cancels: Lazy::new(HashMap::new),
+            queued_watch_requests: SegQueue::new(),
+            waiting_watch_request: Lazy::new(|| None),
+            cancel_req_sender,
+            shutdown,
+            sub_tasks: Some(SegQueue::new()),
+        }
+    }
+
+    /// cancel a watch in async task.
+    async fn cancel_watch(&self, keyrange: KeyRange) {
+        log::debug!("cancel watch {}", keyrange);
+        let mut watched_map = self.watched_map.write().await;
+        if let Some(watchid) = watched_map.remove_watch(&keyrange) {
+            let (tx, rx) = bounded::<()>(1);
+            self.waiting_cancels.write().await.insert(watchid, tx);
+            if self.cancel_req_sender.send(watchid).await.is_ok() {
+                self.sub_tasks
+                    .as_ref()
+                    .unwrap_or_else(|| { panic!("sub_tasks should be some until dropped") })
+                    .push(
+                        smol::spawn(async move {
+                            futures::select! {
+                        _ = smol::Timer::after(Duration::from_secs(WATCH_REQUEST_TIMEOUT_SEC)).into_future().fuse()=>{
+                            // todo: add retry for failed request
+                            // return Err(EtcdError::WaitingResponseTimeout("waiting for cancel response when calling `cancel_watch`".to_owned()));
+                            log::debug!("cancel watch wait response timeout");
+                        }
+                        res = rx.recv().into_future().fuse()=>{
+                            res.unwrap_or_else(|e|{
+                                panic!("receive cancel response channel shouldn't be destroyed, err:{e}");
+                            });
+                            log::debug!("cancel watch successed");
+                        }
+                    }
+                        })
+                    );
+            }
+        } else {
+            panic!("logic bug, cancel watch should be called only when there's watched key");
+        }
+    }
+}
 /// `WatchTunnel` is a reusable connection for `Watch` operation
 /// The underlying `gRPC` method is Bi-directional streaming
+#[allow(dead_code)]
 struct WatchTunnel {
-    /// A channel sender to send watch request.
-    req_sender: Sender<EtcdWatchRequest>,
+    /// A channel sender to send watch request to send loop.
+    watch_req_sender: Sender<(EtcdWatchRequest, Sender<Option<SingleWatchEventReceiver>>)>,
     /// A channel receiver to receive watch response.
-    resp_receiver: Option<Receiver<Result<EtcdWatchResponse>>>,
-    /// A channel sender to send shutdowm request.
-    shutdown: Option<Sender<()>>,
+    // resp_receiver: Option<Receiver<Result<EtcdWatchResponse>>>,
+
+    /// Shared
+    shared: Arc<WatchTunnelShared>,
 }
 
 impl WatchTunnel {
+    #[allow(clippy::too_many_lines)]
     /// Creates a new `WatchClient`.
     fn new(client: &WatchClient) -> Self {
-        let (req_sender, req_receiver) = unbounded::<EtcdWatchRequest>();
-        let (resp_sender, resp_receiver) = unbounded::<Result<EtcdWatchResponse>>();
-
-        let (shutdown_tx, shutdown_rx) = unbounded();
+        let (watch_req_sender, watch_req_receiver) =
+            unbounded::<(EtcdWatchRequest, Sender<Option<SingleWatchEventReceiver>>)>();
+        // todo: cancel operation
+        let (cancel_req_sender, cancel_req_receiver) = unbounded::<WatchID>();
+        // From recv loop to send loop, notify a watch request is done, next watch can be excuted.
+        let (waiting_watch_response_tx, waiting_watch_response_rx) = bounded::<()>(1);
+        let (shutdown_tx, shutdown_rx) = unbounded::<()>();
         let shutdown_reponse = shutdown_rx.clone();
         // Monitor inbound watch response and transfer to the receiver
         let (mut client_req_sender, mut client_resp_receiver) = client
             .watch()
             .unwrap_or_else(|e| panic!("failed to send watch command, the error is: {}", e));
+
+        let shared = Arc::new(WatchTunnelShared::new(cancel_req_sender, shutdown_tx));
+        let shared2 = Arc::clone(&shared);
+        let shared3 = Arc::clone(&shared);
+
+        // Send loop
         smol::spawn(async move {
             let mut shutdown_rx = shutdown_rx.into_future().fuse();
+
             #[allow(clippy::mut_mut)]
-            while let Ok(req) = req_receiver.recv().await {
-                let watch_request: rpc::WatchRequest = req.into();
+            loop {
+                /// send watch request or add to queue or get receiver directly
+                ///  return true if a request is sent
+                async fn handle_watch_request(
+                    client_req_sender: &mut StreamingCallSink<WatchRequest>,
+                    shared: &WatchTunnelShared,
+                    req: EtcdWatchRequest,
+                    send_back: Sender<Option<SingleWatchEventReceiver>>
+                ) -> bool {
+                    let keyrange = KeyRange::range(req.get_key(), req.get_range_end());
+                    // The locking operation on the map here is mutually exclusive with the map operation of cancel_watch.
+                    //  Therefore, the sender to the user will definitely be valid during the map holding period.
+                    let watched_map = shared.watched_map.read().await;
+                    if let Some(event_receiver) = watched_map.get_arc_receiver(&keyrange) {
+                        log::debug!("{} watched directly return", keyrange);
+                        // already watched
+                        if let Err(err) = send_back.send(Some(event_receiver)).await {
+                            panic!(
+                                "Send watch receiver to user failed, Watch canceled, err: {err}"
+                            );
+                        }
+                    } else if shared.waiting_watch_request.read().await.is_some() {
+                        log::debug!("watch queued");
+                        shared.queued_watch_requests.push((req, send_back));
+                    } else {
+                        drop(watched_map);
+                        log::debug!("{} isn't watched, send new watch request", keyrange);
+                        // new watch request
+                        *shared.waiting_watch_request.write().await = Some((keyrange, send_back));
+
+                        client_req_sender
+                            .send((req.into(), WriteFlags::default()))
+                            .fuse().await
+                            .unwrap_or_else(|e| panic!("Fail to send request, the error is {}", e));
+                        // waiting_watch_response=true;
+                        return true;
+                    }
+                    false
+                }
 
                 futures::select! {
-                    res = client_req_sender.send(
-                        (watch_request, WriteFlags::default())
-                    ).fuse() => res.unwrap_or_else(
-                        |e| panic!("Fail to send request, the error is {}", e)
-                    ),
-                    _ = shutdown_rx => return
-                };
+                    //1. Wait new watch request
+                    res = watch_req_receiver.recv().into_future().fuse() => {
+                        // received user
+                        if let Ok((req,send_back)) = res {
+                            handle_watch_request(&mut client_req_sender,&shared,req,send_back).await;
+                        }else{
+                            break;
+                        }
+                    },
+                    //2. wait new cancel request
+                    // send
+                    res = cancel_req_receiver.recv().into_future().fuse() => {
+                        if let Ok(watch_id) = res {
+                            client_req_sender.send(
+                                (EtcdWatchRequest::cancel(watch_id).into(), WriteFlags::default())
+                            ).fuse().await.unwrap_or_else(
+                                |e| panic!("Fail to send request, the error is {}", e)
+                            );
+                        }else{
+                            break;
+                        }
+                    },
+                    //3. wait watch response
+                    // if has queuened request send
+                    _ = waiting_watch_response_rx.recv().into_future().fuse() =>{
+                        // receive when a watch request got its response
+                        // waiting_watch_response=false;
+                        while let Some((req,send_back))= shared.queued_watch_requests.pop(){
+                            log::debug!("handle queued watch request");
+                            if handle_watch_request(&mut client_req_sender,&shared,req,send_back).await{
+                                // left request will be handled after current request get it's response
+                                break;
+                            }
+                        }
+                    },
+                    _ = shutdown_rx => { break; },
+                }
             }
-        })
-        .detach();
-
+        }).detach();
+        // Receive loop
         smol::spawn(async move {
             let mut shutdown_rx = shutdown_reponse.into_future().fuse();
-
             loop {
                 #[allow(clippy::mut_mut)]
-                let resp = futures::select! {
+                let resp =
+                    futures::select! {
                     resp_opt = client_resp_receiver.next().fuse() => resp_opt.unwrap_or_else(
                         || panic!("Fail to receive reponse from client")
                     ),
-                    _ = shutdown_rx => return
+                    _ = shutdown_rx => { return; }
                 };
 
                 match resp {
                     Ok(resp) => {
-                        resp_sender
-                            .send(Ok(From::from(resp)))
-                            .await
-                            .unwrap_or_else(|e| {
-                                panic!("failed to send response, the error is: {}", e)
-                            });
+                        // watch create response
+                        if resp.created {
+                            let (keyrange, send_back) = shared2.waiting_watch_request
+                                .write().await
+                                .take()
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "watch create response must have a waiting create request"
+                                    )
+                                });
+
+                            let (tx, rx) =
+                                async_broadcast::broadcast::<Option<EtcdWatchResponse>>(10);
+                            // let (tx,rx)=unbounded::<Option<EtcdWatchResponse>>();
+                            let receiver_for_user = SingleWatchEventReceiver::new(
+                                Arc::clone(&shared2),
+                                rx,
+                                keyrange.clone()
+                            );
+                            shared2.watched_map
+                                .write().await
+                                .add_watched(
+                                    resp.watch_id,
+                                    keyrange.clone(),
+                                    tx,
+                                    receiver_for_user.get_weak_inner()
+                                );
+                            // send watch result back to user
+                            if let Err(e) = send_back.send(Some(receiver_for_user)).await {
+                                panic!(
+                                    "user receiver shouldn't be dropped before watch response arrive, err:{e}"
+                                );
+                            }
+                            // notify the send loop to handle next watch requests
+                            waiting_watch_response_tx
+                                .send(()).await
+                                .unwrap_or_else(|e| {
+                                    panic!(
+                                        "Failed to send watch resp from recv loop to send loop, err:{e}"
+                                    )
+                                });
+                            log::debug!(
+                                "watch created response received and registed id:{} keyrange:{}",
+                                resp.watch_id,
+                                keyrange
+                            );
+                        } else if resp.canceled {
+                            let sendback = shared2.waiting_cancels
+                                .write().await
+                                .remove(&resp.watch_id)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "watch id must be recorded in `waiting_cancels` before receive cancel respinse"
+                                    )
+                                });
+                            sendback
+                                .send(()).await
+                                .unwrap_or_else(|e| {
+                                    panic!("send back channel shouldn't be destroyed, err:{e}")
+                                });
+                        } else {
+                            // The locking operation on the map here is mutually exclusive with the map operation of cancel_watch.
+                            //  Therefore, the sender to the user will definitely be valid during the map holding period.
+                            let watched_map = shared2.watched_map.read().await;
+                            let sendback = watched_map.get_sender_2_user(resp.watch_id);
+                            if let Some(sender) = sendback {
+                                log::debug!("watch event received and sent");
+                                sender.broadcast(Some(resp.into())).await.unwrap_or_else(|e| {
+                                    panic!(
+                                        "User receiver shouldn't be dropped and send back should work, err:{e}"
+                                    );
+                                });
+                            } else {
+                                log::debug!("received watch event but no user to send to");
+                            }
+                        }
                     }
                     Err(e) => {
-                        resp_sender
-                            .send(Err(From::from(e)))
-                            .await
-                            .unwrap_or_else(|e| {
-                                panic!("failed to send response, the error is: {}", e)
-                            });
+                        log::debug!("Watch end with error: {e}");
+                        break;
                     }
-                };
+                }
             }
-        })
-        .detach();
+        }).detach();
 
         Self {
-            req_sender,
-            resp_receiver: Some(resp_receiver),
-            shutdown: Some(shutdown_tx),
+            watch_req_sender,
+            shared: shared3,
         }
-    }
-
-    /// Takes resp receiver.
-    fn take_resp_receiver(&mut self) -> Receiver<Result<EtcdWatchResponse>> {
-        self.resp_receiver
-            .take()
-            .unwrap_or_else(|| panic!("Take resp_receiver error"))
     }
 }
 
 #[async_trait]
 impl Shutdown for WatchTunnel {
     async fn shutdown(&mut self) -> Result<()> {
-        if let Some(shutdown) = self.shutdown.take() {
-            shutdown.send(()).await?;
-        }
+        self.shared.shutdown.send(()).await?;
         Ok(())
+    }
+}
+
+/// shared inner of `SingleWatchEventReceiver`
+struct SingleWatchEventReceiverInner {
+    /// A receiver to receive etcd watched event
+    receiver: InactiveReceiver<Option<EtcdWatchResponse>>,
+    /// A tunnel used to communicate with Etcd server for watch operations.
+    shared: Arc<WatchTunnelShared>,
+    /// Watched keyrange
+    keyrange: Option<KeyRange>,
+}
+impl Drop for SingleWatchEventReceiverInner {
+    fn drop(&mut self) {
+        // send cancel task to send loop, after sent
+        futures::executor::block_on(async {
+            self.shared
+                .cancel_watch(self.keyrange.take().unwrap_or_else(|| {
+                    panic!("keyrange in SingleWatchEventReceiverInner should be some until dropped")
+                }))
+                .await;
+        });
+    }
+}
+
+/// Watch result return to user
+pub struct SingleWatchEventReceiver {
+    /// The inner arc, when all `SingleWatchEventReceiver` dropped,
+    ///   `SingleWatchEventReceiverInner` fn drop will be triggered.
+    ///   In this drop, we should do the cancel watch operation.
+    inner: Arc<SingleWatchEventReceiverInner>,
+
+    /// A receiver to receive etcd watched event
+    receiver: BroadcastRx<Option<EtcdWatchResponse>>,
+}
+
+impl SingleWatchEventReceiver {
+    /// weak inner will be stored to create new inner
+    ///  if all receivers dropped, weak inner will be invalid
+    fn get_weak_inner(&self) -> Weak<SingleWatchEventReceiverInner> {
+        Arc::downgrade(&self.inner)
+    }
+
+    /// if there's prev watch, an inner will be stored to clone to create new receiver
+    fn from_exist_inner(inner: Arc<SingleWatchEventReceiverInner>) -> Self {
+        let receiver = inner.receiver.activate_cloned();
+
+        Self { inner, receiver }
+    }
+
+    /// new `SingleWatchEventReceiver`
+    /// - `shared` A tunnel used to communicate with Etcd server for watch operations.
+    /// - `receiver` A receiver to receive etcd watched event
+    /// - `keyrange` Watched keyrange
+    fn new(
+        shared: Arc<WatchTunnelShared>,
+        receiver: BroadcastRx<Option<EtcdWatchResponse>>,
+        keyrange: KeyRange,
+    ) -> Self {
+        let inner_receiver = receiver.clone().deactivate();
+        Self {
+            inner: Arc::new(SingleWatchEventReceiverInner {
+                shared,
+                keyrange: Some(keyrange),
+                receiver: inner_receiver,
+            }),
+            receiver,
+        }
+    }
+
+    /// Blocking recv a watch event until system end.
+    pub async fn recv(&mut self) -> Option<EtcdWatchResponse> {
+        match self.receiver.recv().await {
+            Ok(received) => received,
+            Err(err) => {
+                log::debug!("Receive event channel destroyed, the system is closing. err: {err}");
+                None
+            }
+        }
     }
 }
 
@@ -169,34 +547,41 @@ impl Shutdown for WatchTunnel {
 #[derive(Clone)]
 pub struct Watch {
     /// A tunnel used to communicate with Etcd server for watch operations.
-    tunnel: Arc<Lazy<WatchTunnel>>,
+    tunnel: Arc<WatchTunnel>,
 }
 
 impl Watch {
     /// Create a new `WatchClient`.
-    pub(crate) fn new(client: WatchClient) -> Self {
-        let tunnel = { Arc::new(Lazy::new(move || WatchTunnel::new(&client))) };
+    pub(crate) fn new(client: &WatchClient) -> Self {
+        let tunnel = Arc::new(WatchTunnel::new(client));
 
         Self { tunnel }
     }
 
     /// Performs a watch operation.
+    /// Will fail if
     ///
     /// # Panics
     ///
     /// Will panic if send watch request error.
     #[inline]
-    pub async fn watch(
-        &mut self,
-        key_range: KeyRange,
-    ) -> impl Stream<Item = Result<EtcdWatchResponse>> {
-        let mut tunnel = self.tunnel.write().await;
-        tunnel
-            .req_sender
-            .send(EtcdWatchRequest::create(key_range))
+    pub async fn watch(&mut self, key_range: KeyRange) -> Option<SingleWatchEventReceiver> {
+        let (tx, rx) = unbounded();
+        if let Err(err) = self
+            .tunnel
+            .watch_req_sender
+            .send((EtcdWatchRequest::create(key_range), tx))
             .await
-            .unwrap_or_else(|e| panic!("Fail to send watch request, the error is {}", e));
-        tunnel.take_resp_receiver()
+        {
+            log::debug!(
+                "send watch watch request failed, the channel is destroyed and the system is closed, err:{err}"
+            );
+            return None;
+        }
+
+        rx.recv()
+            .await
+            .unwrap_or_else(|e| panic!("watch resp channel shouldn't be ineffective, err:{}", e))
     }
 
     /// Shut down the running watch task, if any.
@@ -208,13 +593,15 @@ impl Watch {
     pub async fn shutdown(&mut self) -> Result<()> {
         // If we implemented `Shutdown` for this, callers would need it in scope in
         // order to call this method.
-        self.tunnel.evict().await
+
+        //todo:shutdown
+        Ok(())
     }
 }
 
 /// The kind of event.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventType {
     /// Put event.
     Put,

--- a/etcd-client/src/watch/watch_impl.rs
+++ b/etcd-client/src/watch/watch_impl.rs
@@ -40,9 +40,9 @@ impl EtcdWatchRequest {
     /// Creates a new `WatchRequest` which will unsubscribe the specified watch.
     #[inline]
     #[must_use]
-    pub fn cancel(watch_id: usize) -> Self {
+    pub fn cancel(watch_id: i64) -> Self {
         let mut watch_cancel_request = WatchCancelRequest::new();
-        watch_cancel_request.set_watch_id(watch_id.cast());
+        watch_cancel_request.set_watch_id(watch_id);
         let mut watch_request = WatchRequest::new();
         watch_request.set_cancel_request(watch_cancel_request);
         Self {
@@ -97,7 +97,17 @@ impl EtcdWatchRequest {
         }
         vec![]
     }
-
+    /// Gets the watch key range end.
+    /// It only effects when the request is for subscribing.
+    #[inline]
+    pub fn get_range_end(&self) -> Vec<u8> {
+        if let &Some(WatchRequest_oneof_request_union::create_request(ref req)) =
+            &self.proto.request_union
+        {
+            return req.get_range_end().to_vec();
+        }
+        vec![]
+    }
     /// Returns if the watch request is a create watch request.
     #[inline]
     pub fn is_create(&self) -> bool {
@@ -115,7 +125,7 @@ impl From<EtcdWatchRequest> for WatchRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Watch Response
 pub struct EtcdWatchResponse {
     /// Etcd watch key response.

--- a/mock-etcd/src/mock_etcd.rs
+++ b/mock-etcd/src/mock_etcd.rs
@@ -963,7 +963,7 @@ mod test {
             let mut resp_receiver = client
                 .watch(KeyRange::range(key000.clone(), key100.clone()))
                 .await
-                .unwrap_or_else(|| panic!("watch failed"));
+                .unwrap_or_else(|e| panic!("watch failed, err {e}"));
 
             let watch_id = 2; // 0-1 is used by e2e_test()
 
@@ -985,19 +985,23 @@ mod test {
             assert_eq!(resp.take_prev_kvs().get(0).unwrap().value(), key000);
 
             for _x in 0..3 {
-                if let Some(resp) = resp_receiver.recv().await {
-                    let mut watch_resp = resp;
-                    assert_eq!(watch_resp.watch_id(), watch_id);
-                    let mut events = watch_resp.take_events();
-                    let event = events
-                        .get_mut(0)
-                        .unwrap_or_else(|| panic!("Fail to take events from watch response"));
-                    let kv = event
-                        .take_kvs()
-                        .unwrap_or_else(|| panic!("Fail to take kvs from watch response"))
-                        .take_key()
-                        .clone();
-                    assert!((kv == key000.clone()) || (kv == key001.clone()));
+                match resp_receiver.recv().await {
+                    Ok(mut watch_resp) => {
+                        assert_eq!(watch_resp.watch_id(), watch_id);
+                        let mut events = watch_resp.take_events();
+                        let event = events
+                            .get_mut(0)
+                            .unwrap_or_else(|| panic!("Fail to take events from watch response"));
+                        let kv = event
+                            .take_kvs()
+                            .unwrap_or_else(|| panic!("Fail to take kvs from watch response"))
+                            .take_key()
+                            .clone();
+                        assert!((kv == key000.clone()) || (kv == key001.clone()));
+                    }
+                    Err(e) => {
+                        panic!("failed to receive watch response, the error is {}", e)
+                    }
                 }
             }
         });

--- a/mock-etcd/src/mock_etcd.rs
+++ b/mock-etcd/src/mock_etcd.rs
@@ -645,9 +645,12 @@ mod test {
         EtcdPutRequest, EtcdRangeRequest, EtcdUnlockRequest, KeyRange,
     };
 
-    use std::sync::Arc;
+    use std::{env::set_var, sync::Arc};
     #[test]
     fn test_all() {
+        set_var("RUST_LOG", "debug");
+        env_logger::init();
+
         unit_test();
         let mut etcd_server = MockEtcdServer::new();
         etcd_server.start();
@@ -963,9 +966,6 @@ mod test {
                 .unwrap_or_else(|| panic!("watch failed"));
 
             let watch_id = 2; // 0-1 is used by e2e_test()
-            if let Some(resp) = resp_receiver.recv().await {
-                assert_eq!(resp.watch_id(), watch_id);
-            }
 
             for key in test_data {
                 client


### PR DESCRIPTION
Detials described in design issue: https://github.com/datenlord/etcd-client/issues/44