### PR TITLE
Handle lock cancel case

### DIFF
--- a/mock-etcd/src/mock_etcd.rs
+++ b/mock-etcd/src/mock_etcd.rs
@@ -31,9 +31,14 @@ use std::time::Duration;
 use utilities::{Cast, OverflowArithmetic};
 
 /// Help function to send success `gRPC` response
-async fn success<R: Send>(response: R, sink: UnarySink<R>) {
+async fn success<R: Send>(response: R, sink: UnarySink<R>, error_context: &str) {
     sink.success(response)
-        .map_err(|e| error!("failed to send response, the error is: {:?}", e))
+        .map_err(|e| {
+            error!(
+                "failed to send response, the error is: {:?}, error_context:{}",
+                e, error_context
+            );
+        })
         .map(|_| ())
         .await;
 }
@@ -45,10 +50,15 @@ fn fail<R>(ctx: &RpcContext, sink: UnarySink<R>, rsc: RpcStatusCode, details: St
         RpcStatusCode::OK,
         "the input RpcStatusCode should not be OK"
     );
-    let rs = RpcStatus::with_message(rsc, details);
+    let rs = RpcStatus::with_message(rsc, details.clone());
     let f = sink
         .fail(rs)
-        .map_err(|e| error!("failed to send response, the error is: {:?}", e))
+        .map_err(move |e| {
+            error!(
+                "failed to send response, the error is: {:?}, details:{}",
+                e, details
+            );
+        })
         .map(|_| ());
     ctx.spawn(f);
 }
@@ -699,7 +709,7 @@ impl Kv for MockEtcd {
             let mut inner = inner_clone.lock().await;
             log::debug!("inner lock range");
 
-            success(Self::range_inner(&mut inner, &req), sink).await;
+            success(Self::range_inner(&mut inner, &req), sink, "range_success").await;
             log::debug!("inner unlocked range");
         };
 
@@ -718,7 +728,7 @@ impl Kv for MockEtcd {
             let mut inner = inner_clone.lock().await;
             log::debug!("inner lock put");
 
-            success(Self::put_inner(&mut inner, &req).await, sink).await;
+            success(Self::put_inner(&mut inner, &req).await, sink, "put_success").await;
             log::debug!("inner unlocked put");
         };
         smol::spawn(task).detach();
@@ -751,7 +761,7 @@ impl Kv for MockEtcd {
 
             // sometimes it can't send the response, so we use a timer to make sure the response is sent
             Timer::after(Duration::from_millis(1000));
-            success(response, sink).await;
+            success(response, sink, "delete success").await;
 
             log::debug!("inner unlock delete_range");
         };
@@ -767,7 +777,7 @@ impl Kv for MockEtcd {
 
             let response = Self::txn_inner(&mut inner, &req).await;
 
-            success(response, sink).await;
+            success(response, sink, "txn success").await;
             log::debug!("inner unlock txn");
         })
         .detach();
@@ -797,19 +807,26 @@ impl Lock for MockEtcd {
 
                 if inner.lock_map.contains(req.get_name()) {
                     drop(inner);
-                    Timer::after(Duration::from_secs(1)).await;
-                    log::debug!("inner unlock `lock`");
+                    log::debug!("inner unlock `lock`,lock is hold by other, wait 300ms for unlock or lease timeout");
+                    Timer::after(Duration::from_millis(300)).await;
                 } else {
-                    inner.lock_map.insert(req.get_name().to_vec());
-                    inner.set_lock_key_2_lease(req.get_lease(), req.get_name().to_vec());
                     let revision = inner.revision.load(Ordering::Relaxed);
-                    drop(inner);
-                    log::debug!("inner unlock `lock`");
+
+                    log::debug!("inner unlock `lock`, lock success");
                     let mut response = LockResponse::new();
                     response.set_key(req.get_name().to_vec());
                     let header = response.mut_header();
                     header.set_revision(revision);
-                    success(response, sink).await;
+                    match sink.success(response).await {
+                        Ok(_) => {
+                            inner.lock_map.insert(req.get_name().to_vec());
+                            inner.set_lock_key_2_lease(req.get_lease(), req.get_name().to_vec());
+                        }
+                        Err(e) => {
+                            warn!("Fail to send lock response, the error is: {}", e);
+                        }
+                    }
+                    drop(inner);
                     break;
                 }
             }
@@ -835,7 +852,7 @@ impl Lock for MockEtcd {
             let mut response = UnlockResponse::new();
             let header = response.mut_header();
             header.set_revision(revision);
-            success(response, sink).await;
+            success(response, sink, "unlock success").await;
         };
 
         smol::spawn(task).detach();
@@ -915,7 +932,7 @@ impl Lease for MockEtcd {
             .detach();
             let mut response = LeaseGrantResponse::new();
             response.set_ID(lease_id);
-            success(response, sink).await;
+            success(response, sink, "lease grant success").await;
         };
 
         smol::spawn(task).detach();
@@ -1388,45 +1405,51 @@ mod test {
     fn e2e_lock_lease_test(client: &Arc<Client>) {
         log::debug!("start e2e_lock_lease_test");
         smol::future::block_on(async {
-            let lock_key012 = vec![0_u8, 1_u8, 2_u8];
-            let res = client
-                .lease()
-                .grant(EtcdLeaseGrantRequest::new(std::time::Duration::from_secs(
-                    5,
-                )))
-                .await
-                .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
-            let lease_id = res.id();
-
-            // lock unlock twice
-            {
-                log::debug!("test basic lock");
-                let mut res = client
-                    .lock()
-                    .lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
-                    .await
-                    .unwrap_or_else(|err| panic!("failed to lock key012, the error is {}", err));
-
-                client
-                    .lock()
-                    .unlock(EtcdUnlockRequest::new(res.take_key()))
+            async fn test_lock_basic(client: Client) {
+                let lock_key012 = vec![0_u8, 1_u8, 2_u8];
+                let res = client
+                    .lease()
+                    .grant(EtcdLeaseGrantRequest::new(std::time::Duration::from_secs(
+                        5,
+                    )))
                     .await
                     .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
+                let lease_id = res.id();
 
-                let mut res = client
-                    .lock()
-                    .lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
-                    .await
-                    .unwrap_or_else(|err| panic!("failed to lock key012, the error is {}", err));
+                // lock unlock twice
+                {
+                    log::debug!("test basic lock");
+                    let mut res = client
+                        .lock()
+                        .lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
+                        .await
+                        .unwrap_or_else(|err| {
+                            panic!("failed to lock key012, the error is {}", err)
+                        });
 
-                client
-                    .lock()
-                    .unlock(EtcdUnlockRequest::new(res.take_key()))
-                    .await
-                    .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
+                    client
+                        .lock()
+                        .unlock(EtcdUnlockRequest::new(res.take_key()))
+                        .await
+                        .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
+
+                    let mut res = client
+                        .lock()
+                        .lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
+                        .await
+                        .unwrap_or_else(|err| {
+                            panic!("failed to lock key012, the error is {}", err)
+                        });
+
+                    client
+                        .lock()
+                        .unlock(EtcdUnlockRequest::new(res.take_key()))
+                        .await
+                        .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
+                }
             }
-
-            {
+            async fn test_lock_lease(client: Client) {
+                let lock_key = "test_lock_lease";
                 // new lease id for new lock
                 let res = client
                     .lease()
@@ -1441,7 +1464,7 @@ mod test {
                 // lock first and the second lock can be return in 5s.
                 let _res = client
                     .lock()
-                    .lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
+                    .lock(EtcdLockRequest::new(lock_key, lease_id))
                     .await
                     .unwrap_or_else(|err| panic!("failed to lock key012, the error is {}", err));
 
@@ -1463,7 +1486,7 @@ mod test {
                         log::debug!("wait for 8s and lock didn't return, {}",(timeout-locked).as_secs());
                         None
                     }
-                    res  = lock.lock(EtcdLockRequest::new(lock_key012.clone(), lease_id)).fuse() => Some(res.unwrap())
+                    res  = lock.lock(EtcdLockRequest::new(lock_key, lease_id)).fuse() => Some(res.unwrap())
                 };
                 let return_time = timestamp();
                 log::debug!(
@@ -1490,7 +1513,7 @@ mod test {
                     }
 
                     let begin_lock = timestamp();
-                    lock.lock(EtcdLockRequest::new(lock_key012.clone(), lease_id))
+                    lock.lock(EtcdLockRequest::new(lock_key, lease_id))
                         .await
                         .unwrap();
                     let end_lock = timestamp();
@@ -1500,6 +1523,52 @@ mod test {
                     );
                 }
             }
+            async fn test_lock_cancel(client: Client) {
+                let lock_key = "test_lock_cancel";
+                // lock will be hold in 30s
+                let res = client
+                    .lease()
+                    .grant(EtcdLeaseGrantRequest::new(std::time::Duration::from_secs(
+                        30,
+                    )))
+                    .await
+                    .unwrap_or_else(|err| panic!("failed to get key 0, the error is {}", err));
+                let lease_id = res.id();
+
+                log::debug!("test lock with lease");
+                // lock first and the second lock can be return in 5s.
+                let mut res = client
+                    .lock()
+                    .lock(EtcdLockRequest::new(lock_key, lease_id))
+                    .await
+                    .unwrap_or_else(|err| panic!("failed to lock key012, the error is {}", err));
+
+                let mut client_lock = client.lock();
+                futures::select! {
+                    _=smol::Timer::after(Duration::from_secs(3)).fuse()=>{
+                        log::debug!("cancel lock");
+                    }
+                    _=client_lock
+                        .lock(EtcdLockRequest::new(lock_key, lease_id)).fuse()=>{
+                        panic!("lock won't be release in 3s")
+                    }
+                }
+
+                //Unlock should be successful because previous lock has not been released.
+                client
+                    .lock()
+                    .unlock(EtcdUnlockRequest::new(res.take_key()))
+                    .await
+                    .expect(
+                        "Unlock should be successful because previous lock has not been released.",
+                    );
+            }
+            let tasks = vec![
+                smol::spawn(test_lock_basic(client.as_ref().clone())),
+                smol::spawn(test_lock_lease(client.as_ref().clone())),
+                smol::spawn(test_lock_cancel(client.as_ref().clone())),
+            ];
+            futures::future::join_all(tasks).await;
         });
     }
 


### PR DESCRIPTION
In the old code we didn't handle the case of client cancel the lock operation. When the user cancel the lock, we will get error when call the response sink. The right operation is to cancel the lock when error occurs or just apply the lock operation when we get ok.